### PR TITLE
adding 'unused' param to the cross call caching function

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -8,8 +8,11 @@ def cross_call_replacement(func):
     and these won't be passed through to the sampling functionality on subsequent calls."""
     already_pulled = []
 
-    def inn(l, num, replace=True):
+    def inn(l, num, replace=True, unused=None):
         if not replace:
+            if unused:
+                for unused_value in unused:
+                    already_pulled.remove(unused_value)
             pass_list = __list_diff_w_dups(l, already_pulled)
             if len(pass_list) < num:
                 raise Exception('not enough remaining unique items to return a list of items that haven\'t been used already')


### PR DESCRIPTION
adjust the cross_call_replacement decorator so that it can take in another param, unused, which it will used to remove these unused items from the already_pulled list. this will allow for us to put the unseen images back into the initial image pool, to be used later for other samples